### PR TITLE
Add codec2 as a dep to enable Codec2 vocoder blocks.

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,9 +1,6 @@
 setlocal EnableDelayedExpansion
 @echo on
 
-:: set pkg-config path so that host deps can be found
-set "PKG_CONFIG_PATH=%LIBRARY_LIB%\pkgconfig;%LIBRARY_PREFIX%\share\pkgconfig"
-
 :: Make a build folder and change to it
 mkdir build
 if errorlevel 1 exit 1

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -33,6 +33,8 @@ cmake -G "Ninja" ^
     -DPYTHON_EXECUTABLE:PATH="%PYTHON%" ^
     -DBoost_NO_BOOST_CMAKE=ON ^
     -DGR_PYTHON_DIR:PATH="%SP_DIR%" ^
+    -DLIBCODEC2_INCLUDE_DIRS="%LIBRARY_INC%\codec2" ^
+    -DLIBCODEC2_LIBRARIES="%LIBRARY_BIN%\libcodec2.dll" ^
     -DMPIR_LIBRARY="%LIBRARY_LIB%\mpir.lib" ^
     -DMPIRXX_LIBRARY="%LIBRARY_LIB%\mpir.lib" ^
     -DPORTAUDIO_LIBRARIES="%LIBRARY_BIN%\libportaudio-2.dll" ^

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -34,7 +34,7 @@ cmake -G "Ninja" ^
     -DBoost_NO_BOOST_CMAKE=ON ^
     -DGR_PYTHON_DIR:PATH="%SP_DIR%" ^
     -DLIBCODEC2_INCLUDE_DIRS="%LIBRARY_INC%\codec2" ^
-    -DLIBCODEC2_LIBRARIES="%LIBRARY_BIN%\libcodec2.dll" ^
+    -DLIBCODEC2_LIBRARIES="%LIBRARY_LIB%\libcodec2.lib" ^
     -DMPIR_LIBRARY="%LIBRARY_LIB%\mpir.lib" ^
     -DMPIRXX_LIBRARY="%LIBRARY_LIB%\mpir.lib" ^
     -DPORTAUDIO_LIBRARIES="%LIBRARY_BIN%\libportaudio-2.dll" ^

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,6 +1,9 @@
 setlocal EnableDelayedExpansion
 @echo on
 
+:: set pkg-config path so that host deps can be found
+set "PKG_CONFIG_PATH=%LIBRARY_LIB%\pkgconfig;%LIBRARY_PREFIX%\share\pkgconfig"
+
 :: Make a build folder and change to it
 mkdir build
 if errorlevel 1 exit 1

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -27,7 +27,7 @@ requirements:
     - {{ compiler('cxx') }}
     - cmake >=3.8
     - ninja
-    - pkg-config
+    - pkg-config  # [not win]
    # libudev needed to link against libusb on linux
     - {{ cdt('libudev') }}  # [linux]
    # below are needed to link with Qt for qtgui

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,7 +18,7 @@ source:
     - 0001-Use-an-ImageSurface-rather-than-UI-back-end.patch  # [osx]
 
 build:
-  number: 9
+  number: 10
   skip: true  # [win and py2k]
 
 requirements:
@@ -50,6 +50,7 @@ requirements:
     - boost-cpp
     - click
     - click-plugins
+    - codec2
     - fftw
     - gsl
     # blas needed to link with gsl
@@ -134,6 +135,7 @@ outputs:
       host:
         - alsa-lib  # [linux]
         - boost-cpp
+        - codec2
         - fftw
         - gsl
         - libblas

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -27,7 +27,7 @@ requirements:
     - {{ compiler('cxx') }}
     - cmake >=3.8
     - ninja
-    - pkg-config  # [not win]
+    - pkg-config
    # libudev needed to link against libusb on linux
     - {{ cdt('libudev') }}  # [linux]
    # below are needed to link with Qt for qtgui


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
