### PR TITLE
Remove hacky workaround for libudev overdepending on libraries

### DIFF
--- a/.scripts/build_steps.sh
+++ b/.scripts/build_steps.sh
@@ -39,7 +39,7 @@ source run_conda_forge_build_setup
 # "recipe/yum_requirements.txt" file. After updating that file,
 # run "conda smithy rerender" and this line will be updated
 # automatically.
-/usr/bin/sudo -n yum install -y mesa-libGL mesa-dri-drivers libselinux libudev libX11 libXcomposite libXcursor libXdamage libXext libXfixes libXi libXinerama libXrandr libXxf86vm
+/usr/bin/sudo -n yum install -y mesa-libGL mesa-dri-drivers libselinux libudev libX11 libXcomposite libXcursor libXdamage libXext libXfixes libXi libXinerama libXrandr libXxf86vm xorg-x11-server-Xvfb
 
 
 # make the build number clobber

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -111,6 +111,8 @@ requirements:
     - python
 
 test:
+  downstreams:
+    - gnuradio-osmosdr
   requires:
     - sqlite
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,7 +17,7 @@ source:
     - 0007-grc-Add-DPI-scale-factor-for-GRC-drawing-area-widget.patch
 
 build:
-  number: 6
+  number: 7
 
 requirements:
   build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -58,15 +58,9 @@ requirements:
     - click
     - click-plugins
     - codec2
-    # *HACK* libudev from systemd-devel links to libdw [elfutils], but we need
-    # it from host so that its dependent libraries match the conda-forge versions
-    - elfutils  # [linux and cdt_name=='cos7']
     - fftw
     - gmp  # [not win]
     - gsl
-    # *HACK* libudev from systemd-devel links to libcap, but we need it from
-    # host so that its dependent libraries match the conda-forge versions
-    - libcap  # [linux and cdt_name=='cos7']
     # blas needed to link with gsl
     - libcblas  # [linux]
     - libsndfile
@@ -145,10 +139,6 @@ outputs:
         # log4cpp is used in block headers, so everything compiling against
         # gnuradio-core will almost-definitely need log4cpp at runtime
         - {{ pin_compatible('log4cpp', max_pin='x.x') }}
-      ignore_run_exports_from:
-        # *HACK* (see below)
-        - elfutils  # [linux and cdt_name=='cos7']
-        - libcap  # [linux and cdt_name=='cos7']
       skip_compile_pyc:
         - "*/templates/*.py"
     requirements:
@@ -162,15 +152,9 @@ outputs:
         - alsa-lib  # [linux]
         - boost-cpp
         - codec2
-        # *HACK* libudev from systemd-devel links to libdw [elfutils], but we need
-        # it from host so that its dependent libraries match the conda-forge versions
-        - elfutils  # [linux and cdt_name=='cos7']
         - fftw
         - gmp  # [not win]
         - gsl
-        # *HACK* libudev from systemd-devel links to libcap, but we need it from
-        # host so that its dependent libraries match the conda-forge versions
-        - libcap  # [linux and cdt_name=='cos7']
         - libcblas  # [linux]
         - libsndfile
         - libthrift  # [not win]
@@ -187,13 +171,7 @@ outputs:
         - boost-cpp
         - click
         - click-plugins
-        # *HACK* libudev from systemd-devel links to libdw [elfutils], and we
-        # want it installed from conda-forge at runtime to ensure compatibility
-        - {{ pin_compatible('elfutils', min_pin='x') }}  # [linux and cdt_name=='cos7']
         - fftw
-        # *HACK* libudev from systemd-devel links to libdw [elfutils], and we
-        # want it installed from conda-forge at runtime to ensure compatibility
-        - {{ pin_compatible('libcap', min_pin='x') }}  # [linux and cdt_name=='cos7']
         - mako
         - menuinst  # [win]
         - numpy
@@ -243,9 +221,6 @@ outputs:
       entry_points:
         - gnuradio-companion = gnuradio.grc.main:main  # [win]
         - grcc = gnuradio.grc.compiler:main  # [win]
-      ignore_run_exports_from:
-        # *HACK* (see above)
-        - elfutils  # [linux and cdt_name=='cos7']
     requirements:
       build:
         - {{ compiler('c') }}
@@ -259,8 +234,6 @@ outputs:
         - gtk3
         - log4cpp
         - python
-        # *HACK* (see above)
-        - elfutils  # [linux and cdt_name=='cos7']
       run:
         - boost-cpp
         - {{ pin_subpackage('gnuradio-core', exact=True) }}
@@ -287,9 +260,6 @@ outputs:
   - name: gnuradio-qtgui
     build:
       skip: true  # [ppc64le or arm64]
-      ignore_run_exports_from:
-        # *HACK* (see above)
-        - elfutils  # [linux and cdt_name=='cos7']
     script: install_qtgui.sh  # [not win]
     script: install_qtgui.bat  # [win]
     requirements:
@@ -308,8 +278,6 @@ outputs:
         - qt
         - qwt <6.2
         - volk
-        # *HACK* (see above)
-        - elfutils  # [linux and cdt_name=='cos7']
       run:
         - {{ pin_subpackage('gnuradio-core', exact=True) }}
         - pyqt
@@ -329,10 +297,6 @@ outputs:
   - name: gnuradio-soapy-intree
     script: install_soapy.sh  # [not win]
     script: install_soapy.bat  # [win]
-    build:
-      ignore_run_exports_from:
-        # *HACK* (see above)
-        - elfutils  # [linux and cdt_name=='cos7']
     requirements:
       build:
         - {{ compiler('c') }}
@@ -346,8 +310,6 @@ outputs:
         - log4cpp
         - python
         - soapysdr
-        # *HACK* (see above)
-        - elfutils  # [linux and cdt_name=='cos7']
       run:
         - {{ pin_subpackage('gnuradio-core', exact=True) }}
         - python
@@ -372,9 +334,6 @@ outputs:
     build:
       entry_points:
         - uhd_siggen = gnuradio.uhd.uhd_siggen_base:main  # [win]
-      ignore_run_exports_from:
-        # *HACK* (see above)
-        - elfutils  # [linux and cdt_name=='cos7']
     requirements:
       build:
         - {{ compiler('c') }}
@@ -388,8 +347,6 @@ outputs:
         - log4cpp
         - python
         - uhd
-        # *HACK* (see above)
-        - elfutils  # [linux and cdt_name=='cos7']
       run:
         - boost-cpp
         - {{ pin_subpackage('gnuradio-core', exact=True) }}
@@ -410,10 +367,6 @@ outputs:
   - name: gnuradio-video-sdl
     script: install_video_sdl.sh  # [not win]
     script: install_video_sdl.bat  # [win]
-    build:
-      ignore_run_exports_from:
-        # *HACK* (see above)
-        - elfutils  # [linux and cdt_name=='cos7']
     requirements:
       build:
         - {{ compiler('c') }}
@@ -427,8 +380,6 @@ outputs:
         - log4cpp
         - python
         - sdl
-        # *HACK* (see above)
-        - elfutils  # [linux and cdt_name=='cos7']
       run:
         - {{ pin_subpackage('gnuradio-core', exact=True) }}
         - python
@@ -446,10 +397,6 @@ outputs:
   - name: gnuradio-zeromq
     script: install_zeromq.sh  # [not win]
     script: install_zeromq.bat  # [win]
-    build:
-      ignore_run_exports_from:
-        # *HACK* (see above)
-        - elfutils  # [linux and cdt_name=='cos7']
     requirements:
       build:
         - {{ compiler('c') }}
@@ -464,8 +411,6 @@ outputs:
         - log4cpp
         - python
         - zeromq
-        # *HACK* (see above)
-        - elfutils  # [linux and cdt_name=='cos7']
       run:
         - boost-cpp
         - {{ pin_subpackage('gnuradio-core', exact=True) }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -113,6 +113,7 @@ requirements:
 test:
   downstreams:
     - gnuradio-osmosdr
+    - gnuradio-satellites
   requires:
     - sqlite
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -33,10 +33,9 @@ requirements:
     - cross-python_{{ target_platform }}  # [build_platform != target_platform]
     - pybind11                            # [build_platform != target_platform]
     - numpy                               # [build_platform != target_platform]
-    # libudev needed to link against libusb through uhd on linux
-    # libudev is on its own in CentOS 6, packaged with systemd in CentOS 7
+    # libudev CDT needed to link against libusb through uhd on linux CentOS 6
+    # libusb uses the conda-forge libudev package for CentOS 7
     - {{ cdt('libudev-devel') }}  # [linux and cdt_name=='cos6']
-    - {{ cdt('systemd-devel') }}  # [linux and cdt_name=='cos7']
     # below are needed to link with Qt for qtgui
     - {{ cdt('libice') }}  # [linux and not ppc64le]
     - {{ cdt('libselinux') }}  # [linux and not ppc64le]

--- a/recipe/yum_requirements.txt
+++ b/recipe/yum_requirements.txt
@@ -12,3 +12,4 @@ libXi
 libXinerama
 libXrandr
 libXxf86vm
+xorg-x11-server-Xvfb


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
