### PR TITLE
[ci skip] ***NO_CI*** Modify jinja to fix rendering for cf-scripts pinning update

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -508,7 +508,7 @@ outputs:
       summary: GNU Radio ZeroMQ module for message passing functionality
   - name: gnuradio-build-deps
     build:
-      string: {{ pin_subpackage('gnuradio-core', exact=True).partition(' ')[-1].partition(' ')[-1] }}
+      string: {{ (pin_subpackage('gnuradio-core', exact=True) if (pin_subpackage('gnuradio-core', exact=True) is string) else '').partition(' ')[-1].partition(' ')[-1] }}
     requirements:
       host:
         # need to populate host to get complete build string (why?)

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -520,7 +520,7 @@ outputs:
         - {{ compiler('cxx') }}
         - cmake
         - ninja
-        - numpy {{ numpy }}
+        - numpy {{ numpy }}.*
         - pip  # [win]
         - pkg-config
         - pybind11


### PR DESCRIPTION
When cf-scripts (regro-cf-autotick-bot) parses the meta.yaml to
determine if the global pinning needs to be updated, it uses stub
versions of the jinja functions instead of the actual versions. In this
case, `pin_subpackage` returns a dictionary instead of a string, so the
string parsing for the build string of gnuradio-build-deps causes an
exception. Adding logic to ensure that the build string is empty when
`pin_subpackage` returns a non-string fixes this.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
