### PR TITLE
Add patches to remove excessive gmp linking and export the C++17 std for gnuradio-runtime

### DIFF
--- a/recipe/0005-fix-pkg-config.patch
+++ b/recipe/0005-fix-pkg-config.patch
@@ -1,0 +1,84 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: "A. Maitland Bottoms" <bottoms@debian.org>
+Date: Sat, 23 Oct 2021 23:34:57 -0400
+Subject: [PATCH] fix pkg config
+
+No need to propagate PC_ADD_LIBS into gnuradio-runtime.pc.
+---
+ cmake/Modules/FindGMP.cmake             | 1 -
+ cmake/Modules/FindMPIR.cmake            | 1 -
+ cmake/Modules/FindMPLIB.cmake           | 2 --
+ gnuradio-runtime/CMakeLists.txt         | 1 -
+ gnuradio-runtime/gnuradio-runtime.pc.in | 2 +-
+ 5 files changed, 1 insertion(+), 6 deletions(-)
+
+diff --git a/cmake/Modules/FindGMP.cmake b/cmake/Modules/FindGMP.cmake
+index 62f9a4392..d1c89a7f0 100644
+--- a/cmake/Modules/FindGMP.cmake
++++ b/cmake/Modules/FindGMP.cmake
+@@ -38,7 +38,6 @@ find_library(
+           /usr/lib64
+ )
+ set(GMP_LIBRARIES ${GMPXX_LIBRARY} ${GMP_LIBRARY})
+-set(GMP_PC_ADD_LIBS "-lgmpxx -lgmp")
+ 
+ include(FindPackageHandleStandardArgs)
+ find_package_handle_standard_args(GMP DEFAULT_MSG GMPXX_LIBRARY GMP_LIBRARY GMP_INCLUDE_DIR)
+diff --git a/cmake/Modules/FindMPIR.cmake b/cmake/Modules/FindMPIR.cmake
+index f31714cca..bb88f6741 100644
+--- a/cmake/Modules/FindMPIR.cmake
++++ b/cmake/Modules/FindMPIR.cmake
+@@ -39,7 +39,6 @@ find_library(
+           /usr/lib64
+ )
+ set(MPIR_LIBRARIES ${MPIRXX_LIBRARY} ${MPIR_LIBRARY})
+-set(MPIR_PC_ADD_LIBS "-lmpirxx -lmpir")
+ 
+ include(FindPackageHandleStandardArgs)
+ find_package_handle_standard_args(MPIR DEFAULT_MSG MPIRXX_LIBRARY MPIR_LIBRARY MPIR_INCLUDE_DIR)
+diff --git a/cmake/Modules/FindMPLIB.cmake b/cmake/Modules/FindMPLIB.cmake
+index daa381b64..11c9eeda6 100644
+--- a/cmake/Modules/FindMPLIB.cmake
++++ b/cmake/Modules/FindMPLIB.cmake
+@@ -8,7 +8,6 @@ if(GMP_FOUND)
+     set(MPLIB_LIBRARY ${GMP_LIBRARY})
+     set(MPLIBXX_LIBRARY ${GMPXX_LIBRARY})
+     set(MPLIB_PC_ADD_CFLAGS ${GMP_PC_ADD_CFLAGS})
+-    set(MPLIB_PC_ADD_LIBS ${GMP_PC_ADD_LIBS})
+ else(GMP_FOUND)
+     message(STATUS "GMP not found; this is not a problem if MPIR can be found.")
+     find_package(MPIR REQUIRED)
+@@ -19,7 +18,6 @@ else(GMP_FOUND)
+     set(MPLIB_LIBRARY ${MPIR_LIBRARY})
+     set(MPLIBXX_LIBRARY ${MPIRXX_LIBRARY})
+     set(MPLIB_PC_ADD_CFLAGS ${MPIR_PC_ADD_CFLAGS})
+-    set(MPLIB_PC_ADD_LIBS ${MPIR_PC_ADD_LIBS})
+ endif(GMP_FOUND)
+ 
+ set(MPLIB_INCLUDE_DIRS ${MPLIB_INCLUDE_DIR})
+diff --git a/gnuradio-runtime/CMakeLists.txt b/gnuradio-runtime/CMakeLists.txt
+index 5160e76d8..6c9e746fc 100644
+--- a/gnuradio-runtime/CMakeLists.txt
++++ b/gnuradio-runtime/CMakeLists.txt
+@@ -129,7 +129,6 @@ install(FILES
+     DESTINATION ${GR_PREFSDIR}
+ )
+ 
+-set(PC_ADD_LIBS "${MPLIB_PC_ADD_LIBS} ${PC_ADD_LIBS}")
+ set(PC_ADD_CFLAGS ${MPLIB_PC_ADD_CFLAGS})
+ 
+ ########################################################################
+diff --git a/gnuradio-runtime/gnuradio-runtime.pc.in b/gnuradio-runtime/gnuradio-runtime.pc.in
+index 280adaddd..e10deceb9 100644
+--- a/gnuradio-runtime/gnuradio-runtime.pc.in
++++ b/gnuradio-runtime/gnuradio-runtime.pc.in
+@@ -7,5 +7,5 @@ Name: gnuradio-runtime
+ Description: GNU Radio core runtime infrastructure
+ Requires:
+ Version: @LIBVER@
+-Libs: -L${libdir} -lgnuradio-runtime -lgnuradio-pmt @PC_ADD_LIBS@
++Libs: -L${libdir} -lgnuradio-runtime -lgnuradio-pmt
+ Cflags: -I${includedir} @PC_ADD_CFLAGS@
+-- 
+2.34.1
+

--- a/recipe/0006-cmake-runtime-Set-target_compile_features-to-cxx_std.patch
+++ b/recipe/0006-cmake-runtime-Set-target_compile_features-to-cxx_std.patch
@@ -1,0 +1,31 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Ryan Volz <ryan.volz@gmail.com>
+Date: Thu, 27 Jan 2022 22:26:01 -0500
+Subject: [PATCH] cmake: runtime: Set target_compile_features to cxx_std_17.
+
+Since gnuradio-runtime uses C++17 features, this tells CMake to require
+a compiler with those features enabled and also communicates that
+information to other libraries that compile against gnuradio-runtime and
+inherit the use of C++17 features from the public headers.
+
+Signed-off-by: Ryan Volz <ryan.volz@gmail.com>
+---
+ gnuradio-runtime/lib/CMakeLists.txt | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/gnuradio-runtime/lib/CMakeLists.txt b/gnuradio-runtime/lib/CMakeLists.txt
+index 6cd9c0c54..4e7670b73 100644
+--- a/gnuradio-runtime/lib/CMakeLists.txt
++++ b/gnuradio-runtime/lib/CMakeLists.txt
+@@ -166,6 +166,8 @@ target_include_directories(gnuradio-runtime
+     ${CMAKE_CURRENT_SOURCE_DIR}
+     )
+ 
++target_compile_features(gnuradio-runtime PUBLIC cxx_std_17)
++
+ target_compile_definitions(gnuradio-runtime PUBLIC ${MPLIB_DEFINITIONS})
+ 
+ # constants.cc includes boost::dll headers, force them to use std::filesystem
+-- 
+2.34.1
+

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,6 +13,7 @@ source:
     - 0003-Use-an-ImageSurface-rather-than-UI-back-end.patch  # [osx]
     - 0004-grc-Remove-global_blocks_path-preference-and-use-pre.patch
     - 0005-fix-pkg-config.patch
+    - 0006-cmake-runtime-Set-target_compile_features-to-cxx_std.patch
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,6 +12,7 @@ source:
     - 0002-cmake-Don-t-generate-.pyc-and-.pyo-files.patch
     - 0003-Use-an-ImageSurface-rather-than-UI-back-end.patch  # [osx]
     - 0004-grc-Remove-global_blocks_path-preference-and-use-pre.patch
+    - 0005-fix-pkg-config.patch
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,7 +16,7 @@ source:
     - 0006-cmake-runtime-Set-target_compile_features-to-cxx_std.patch
 
 build:
-  number: 0
+  number: 1
 
 requirements:
   build:


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
