### PR TITLE
(DO NOT MERGE) Remove fmt10 migration to build for globally-pinned fmt

### DIFF
--- a/.ci_support/linux_64_numpy1.22python3.10.____cpython.yaml
+++ b/.ci_support/linux_64_numpy1.22python3.10.____cpython.yaml
@@ -19,7 +19,7 @@ docker_image:
 fftw:
 - '3'
 fmt:
-- '10'
+- '9'
 gmp:
 - '6'
 gsl:
@@ -49,7 +49,7 @@ qt_main:
 soapysdr:
 - '0.8'
 spdlog:
-- '1.12'
+- '1.11'
 sqlite:
 - '3'
 target_platform:

--- a/.ci_support/linux_64_numpy1.22python3.8.____cpython.yaml
+++ b/.ci_support/linux_64_numpy1.22python3.8.____cpython.yaml
@@ -19,7 +19,7 @@ docker_image:
 fftw:
 - '3'
 fmt:
-- '10'
+- '9'
 gmp:
 - '6'
 gsl:
@@ -49,7 +49,7 @@ qt_main:
 soapysdr:
 - '0.8'
 spdlog:
-- '1.12'
+- '1.11'
 sqlite:
 - '3'
 target_platform:

--- a/.ci_support/linux_64_numpy1.22python3.9.____cpython.yaml
+++ b/.ci_support/linux_64_numpy1.22python3.9.____cpython.yaml
@@ -19,7 +19,7 @@ docker_image:
 fftw:
 - '3'
 fmt:
-- '10'
+- '9'
 gmp:
 - '6'
 gsl:
@@ -49,7 +49,7 @@ qt_main:
 soapysdr:
 - '0.8'
 spdlog:
-- '1.12'
+- '1.11'
 sqlite:
 - '3'
 target_platform:

--- a/.ci_support/linux_64_numpy1.23python3.11.____cpython.yaml
+++ b/.ci_support/linux_64_numpy1.23python3.11.____cpython.yaml
@@ -19,7 +19,7 @@ docker_image:
 fftw:
 - '3'
 fmt:
-- '10'
+- '9'
 gmp:
 - '6'
 gsl:
@@ -49,7 +49,7 @@ qt_main:
 soapysdr:
 - '0.8'
 spdlog:
-- '1.12'
+- '1.11'
 sqlite:
 - '3'
 target_platform:

--- a/.ci_support/linux_64_numpy1.26python3.12.____cpython.yaml
+++ b/.ci_support/linux_64_numpy1.26python3.12.____cpython.yaml
@@ -19,7 +19,7 @@ docker_image:
 fftw:
 - '3'
 fmt:
-- '10'
+- '9'
 gmp:
 - '6'
 gsl:
@@ -49,7 +49,7 @@ qt_main:
 soapysdr:
 - '0.8'
 spdlog:
-- '1.12'
+- '1.11'
 sqlite:
 - '3'
 target_platform:

--- a/.ci_support/linux_aarch64_numpy1.22python3.10.____cpython.yaml
+++ b/.ci_support/linux_aarch64_numpy1.22python3.10.____cpython.yaml
@@ -23,7 +23,7 @@ docker_image:
 fftw:
 - '3'
 fmt:
-- '10'
+- '9'
 gmp:
 - '6'
 gsl:
@@ -53,7 +53,7 @@ qt_main:
 soapysdr:
 - '0.8'
 spdlog:
-- '1.12'
+- '1.11'
 sqlite:
 - '3'
 target_platform:

--- a/.ci_support/linux_aarch64_numpy1.22python3.8.____cpython.yaml
+++ b/.ci_support/linux_aarch64_numpy1.22python3.8.____cpython.yaml
@@ -23,7 +23,7 @@ docker_image:
 fftw:
 - '3'
 fmt:
-- '10'
+- '9'
 gmp:
 - '6'
 gsl:
@@ -53,7 +53,7 @@ qt_main:
 soapysdr:
 - '0.8'
 spdlog:
-- '1.12'
+- '1.11'
 sqlite:
 - '3'
 target_platform:

--- a/.ci_support/linux_aarch64_numpy1.22python3.9.____cpython.yaml
+++ b/.ci_support/linux_aarch64_numpy1.22python3.9.____cpython.yaml
@@ -23,7 +23,7 @@ docker_image:
 fftw:
 - '3'
 fmt:
-- '10'
+- '9'
 gmp:
 - '6'
 gsl:
@@ -53,7 +53,7 @@ qt_main:
 soapysdr:
 - '0.8'
 spdlog:
-- '1.12'
+- '1.11'
 sqlite:
 - '3'
 target_platform:

--- a/.ci_support/linux_aarch64_numpy1.23python3.11.____cpython.yaml
+++ b/.ci_support/linux_aarch64_numpy1.23python3.11.____cpython.yaml
@@ -23,7 +23,7 @@ docker_image:
 fftw:
 - '3'
 fmt:
-- '10'
+- '9'
 gmp:
 - '6'
 gsl:
@@ -53,7 +53,7 @@ qt_main:
 soapysdr:
 - '0.8'
 spdlog:
-- '1.12'
+- '1.11'
 sqlite:
 - '3'
 target_platform:

--- a/.ci_support/linux_aarch64_numpy1.26python3.12.____cpython.yaml
+++ b/.ci_support/linux_aarch64_numpy1.26python3.12.____cpython.yaml
@@ -23,7 +23,7 @@ docker_image:
 fftw:
 - '3'
 fmt:
-- '10'
+- '9'
 gmp:
 - '6'
 gsl:
@@ -53,7 +53,7 @@ qt_main:
 soapysdr:
 - '0.8'
 spdlog:
-- '1.12'
+- '1.11'
 sqlite:
 - '3'
 target_platform:

--- a/.ci_support/linux_ppc64le_numpy1.22python3.10.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_numpy1.22python3.10.____cpython.yaml
@@ -19,7 +19,7 @@ docker_image:
 fftw:
 - '3'
 fmt:
-- '10'
+- '9'
 gmp:
 - '6'
 gsl:
@@ -49,7 +49,7 @@ qt_main:
 soapysdr:
 - '0.8'
 spdlog:
-- '1.12'
+- '1.11'
 sqlite:
 - '3'
 target_platform:

--- a/.ci_support/linux_ppc64le_numpy1.22python3.8.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_numpy1.22python3.8.____cpython.yaml
@@ -19,7 +19,7 @@ docker_image:
 fftw:
 - '3'
 fmt:
-- '10'
+- '9'
 gmp:
 - '6'
 gsl:
@@ -49,7 +49,7 @@ qt_main:
 soapysdr:
 - '0.8'
 spdlog:
-- '1.12'
+- '1.11'
 sqlite:
 - '3'
 target_platform:

--- a/.ci_support/linux_ppc64le_numpy1.22python3.9.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_numpy1.22python3.9.____cpython.yaml
@@ -19,7 +19,7 @@ docker_image:
 fftw:
 - '3'
 fmt:
-- '10'
+- '9'
 gmp:
 - '6'
 gsl:
@@ -49,7 +49,7 @@ qt_main:
 soapysdr:
 - '0.8'
 spdlog:
-- '1.12'
+- '1.11'
 sqlite:
 - '3'
 target_platform:

--- a/.ci_support/linux_ppc64le_numpy1.23python3.11.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_numpy1.23python3.11.____cpython.yaml
@@ -19,7 +19,7 @@ docker_image:
 fftw:
 - '3'
 fmt:
-- '10'
+- '9'
 gmp:
 - '6'
 gsl:
@@ -49,7 +49,7 @@ qt_main:
 soapysdr:
 - '0.8'
 spdlog:
-- '1.12'
+- '1.11'
 sqlite:
 - '3'
 target_platform:

--- a/.ci_support/linux_ppc64le_numpy1.26python3.12.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_numpy1.26python3.12.____cpython.yaml
@@ -19,7 +19,7 @@ docker_image:
 fftw:
 - '3'
 fmt:
-- '10'
+- '9'
 gmp:
 - '6'
 gsl:
@@ -49,7 +49,7 @@ qt_main:
 soapysdr:
 - '0.8'
 spdlog:
-- '1.12'
+- '1.11'
 sqlite:
 - '3'
 target_platform:

--- a/.ci_support/migrations/fmt10.yaml
+++ b/.ci_support/migrations/fmt10.yaml
@@ -1,7 +1,0 @@
-__migrator:
-  build_number: 1
-  kind: version
-  migration_number: 1
-fmt:
-- '10'
-migrator_ts: 1683802784.4940007

--- a/.ci_support/osx_64_numpy1.22python3.10.____cpython.yaml
+++ b/.ci_support/osx_64_numpy1.22python3.10.____cpython.yaml
@@ -15,7 +15,7 @@ cxx_compiler_version:
 fftw:
 - '3'
 fmt:
-- '10'
+- '9'
 gmp:
 - '6'
 gsl:
@@ -47,7 +47,7 @@ qt_main:
 soapysdr:
 - '0.8'
 spdlog:
-- '1.12'
+- '1.11'
 sqlite:
 - '3'
 target_platform:

--- a/.ci_support/osx_64_numpy1.22python3.8.____cpython.yaml
+++ b/.ci_support/osx_64_numpy1.22python3.8.____cpython.yaml
@@ -15,7 +15,7 @@ cxx_compiler_version:
 fftw:
 - '3'
 fmt:
-- '10'
+- '9'
 gmp:
 - '6'
 gsl:
@@ -47,7 +47,7 @@ qt_main:
 soapysdr:
 - '0.8'
 spdlog:
-- '1.12'
+- '1.11'
 sqlite:
 - '3'
 target_platform:

--- a/.ci_support/osx_64_numpy1.22python3.9.____cpython.yaml
+++ b/.ci_support/osx_64_numpy1.22python3.9.____cpython.yaml
@@ -15,7 +15,7 @@ cxx_compiler_version:
 fftw:
 - '3'
 fmt:
-- '10'
+- '9'
 gmp:
 - '6'
 gsl:
@@ -47,7 +47,7 @@ qt_main:
 soapysdr:
 - '0.8'
 spdlog:
-- '1.12'
+- '1.11'
 sqlite:
 - '3'
 target_platform:

--- a/.ci_support/osx_64_numpy1.23python3.11.____cpython.yaml
+++ b/.ci_support/osx_64_numpy1.23python3.11.____cpython.yaml
@@ -15,7 +15,7 @@ cxx_compiler_version:
 fftw:
 - '3'
 fmt:
-- '10'
+- '9'
 gmp:
 - '6'
 gsl:
@@ -47,7 +47,7 @@ qt_main:
 soapysdr:
 - '0.8'
 spdlog:
-- '1.12'
+- '1.11'
 sqlite:
 - '3'
 target_platform:

--- a/.ci_support/osx_64_numpy1.26python3.12.____cpython.yaml
+++ b/.ci_support/osx_64_numpy1.26python3.12.____cpython.yaml
@@ -15,7 +15,7 @@ cxx_compiler_version:
 fftw:
 - '3'
 fmt:
-- '10'
+- '9'
 gmp:
 - '6'
 gsl:
@@ -47,7 +47,7 @@ qt_main:
 soapysdr:
 - '0.8'
 spdlog:
-- '1.12'
+- '1.11'
 sqlite:
 - '3'
 target_platform:

--- a/.ci_support/osx_arm64_numpy1.22python3.10.____cpython.yaml
+++ b/.ci_support/osx_arm64_numpy1.22python3.10.____cpython.yaml
@@ -15,7 +15,7 @@ cxx_compiler_version:
 fftw:
 - '3'
 fmt:
-- '10'
+- '9'
 gmp:
 - '6'
 gsl:
@@ -47,7 +47,7 @@ qt_main:
 soapysdr:
 - '0.8'
 spdlog:
-- '1.12'
+- '1.11'
 sqlite:
 - '3'
 target_platform:

--- a/.ci_support/osx_arm64_numpy1.22python3.8.____cpython.yaml
+++ b/.ci_support/osx_arm64_numpy1.22python3.8.____cpython.yaml
@@ -15,7 +15,7 @@ cxx_compiler_version:
 fftw:
 - '3'
 fmt:
-- '10'
+- '9'
 gmp:
 - '6'
 gsl:
@@ -47,7 +47,7 @@ qt_main:
 soapysdr:
 - '0.8'
 spdlog:
-- '1.12'
+- '1.11'
 sqlite:
 - '3'
 target_platform:

--- a/.ci_support/osx_arm64_numpy1.22python3.9.____cpython.yaml
+++ b/.ci_support/osx_arm64_numpy1.22python3.9.____cpython.yaml
@@ -15,7 +15,7 @@ cxx_compiler_version:
 fftw:
 - '3'
 fmt:
-- '10'
+- '9'
 gmp:
 - '6'
 gsl:
@@ -47,7 +47,7 @@ qt_main:
 soapysdr:
 - '0.8'
 spdlog:
-- '1.12'
+- '1.11'
 sqlite:
 - '3'
 target_platform:

--- a/.ci_support/osx_arm64_numpy1.23python3.11.____cpython.yaml
+++ b/.ci_support/osx_arm64_numpy1.23python3.11.____cpython.yaml
@@ -15,7 +15,7 @@ cxx_compiler_version:
 fftw:
 - '3'
 fmt:
-- '10'
+- '9'
 gmp:
 - '6'
 gsl:
@@ -47,7 +47,7 @@ qt_main:
 soapysdr:
 - '0.8'
 spdlog:
-- '1.12'
+- '1.11'
 sqlite:
 - '3'
 target_platform:

--- a/.ci_support/osx_arm64_numpy1.26python3.12.____cpython.yaml
+++ b/.ci_support/osx_arm64_numpy1.26python3.12.____cpython.yaml
@@ -15,7 +15,7 @@ cxx_compiler_version:
 fftw:
 - '3'
 fmt:
-- '10'
+- '9'
 gmp:
 - '6'
 gsl:
@@ -47,7 +47,7 @@ qt_main:
 soapysdr:
 - '0.8'
 spdlog:
-- '1.12'
+- '1.11'
 sqlite:
 - '3'
 target_platform:

--- a/.ci_support/win_64_numpy1.22python3.10.____cpython.yaml
+++ b/.ci_support/win_64_numpy1.22python3.10.____cpython.yaml
@@ -9,7 +9,7 @@ cxx_compiler:
 fftw:
 - '3'
 fmt:
-- '10'
+- '9'
 gsl:
 - '2.7'
 libboost_devel:
@@ -35,7 +35,7 @@ qt_main:
 soapysdr:
 - '0.8'
 spdlog:
-- '1.12'
+- '1.11'
 sqlite:
 - '3'
 target_platform:

--- a/.ci_support/win_64_numpy1.22python3.8.____cpython.yaml
+++ b/.ci_support/win_64_numpy1.22python3.8.____cpython.yaml
@@ -9,7 +9,7 @@ cxx_compiler:
 fftw:
 - '3'
 fmt:
-- '10'
+- '9'
 gsl:
 - '2.7'
 libboost_devel:
@@ -35,7 +35,7 @@ qt_main:
 soapysdr:
 - '0.8'
 spdlog:
-- '1.12'
+- '1.11'
 sqlite:
 - '3'
 target_platform:

--- a/.ci_support/win_64_numpy1.22python3.9.____cpython.yaml
+++ b/.ci_support/win_64_numpy1.22python3.9.____cpython.yaml
@@ -9,7 +9,7 @@ cxx_compiler:
 fftw:
 - '3'
 fmt:
-- '10'
+- '9'
 gsl:
 - '2.7'
 libboost_devel:
@@ -35,7 +35,7 @@ qt_main:
 soapysdr:
 - '0.8'
 spdlog:
-- '1.12'
+- '1.11'
 sqlite:
 - '3'
 target_platform:

--- a/.ci_support/win_64_numpy1.23python3.11.____cpython.yaml
+++ b/.ci_support/win_64_numpy1.23python3.11.____cpython.yaml
@@ -9,7 +9,7 @@ cxx_compiler:
 fftw:
 - '3'
 fmt:
-- '10'
+- '9'
 gsl:
 - '2.7'
 libboost_devel:
@@ -35,7 +35,7 @@ qt_main:
 soapysdr:
 - '0.8'
 spdlog:
-- '1.12'
+- '1.11'
 sqlite:
 - '3'
 target_platform:

--- a/.ci_support/win_64_numpy1.26python3.12.____cpython.yaml
+++ b/.ci_support/win_64_numpy1.26python3.12.____cpython.yaml
@@ -9,7 +9,7 @@ cxx_compiler:
 fftw:
 - '3'
 fmt:
-- '10'
+- '9'
 gsl:
 - '2.7'
 libboost_devel:
@@ -35,7 +35,7 @@ qt_main:
 soapysdr:
 - '0.8'
 spdlog:
-- '1.12'
+- '1.11'
 sqlite:
 - '3'
 target_platform:

--- a/.scripts/build_steps.sh
+++ b/.scripts/build_steps.sh
@@ -34,9 +34,9 @@ CONDARC
 export CONDA_LIBMAMBA_SOLVER_NO_CHANNELS_FROM_INSTALLED=1
 
 mamba install --update-specs --yes --quiet --channel conda-forge --strict-channel-priority \
-    pip mamba conda-build conda-forge-ci-setup=4
+    pip mamba conda-build boa conda-forge-ci-setup=4
 mamba update --update-specs --yes --quiet --channel conda-forge --strict-channel-priority \
-    pip mamba conda-build conda-forge-ci-setup=4
+    pip mamba conda-build boa conda-forge-ci-setup=4
 
 # set up the condarc
 setup_conda_rc "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"
@@ -82,7 +82,7 @@ if [[ "${BUILD_WITH_CONDA_DEBUG:-0}" == 1 ]]; then
     # Drop into an interactive shell
     /bin/bash
 else
-    conda build "${RECIPE_ROOT}" -m "${CI_SUPPORT}/${CONFIG}.yaml" \
+    conda mambabuild "${RECIPE_ROOT}" -m "${CI_SUPPORT}/${CONFIG}.yaml" \
         --suppress-variables ${EXTRA_CB_OPTIONS:-} \
         --clobber-file "${CI_SUPPORT}/clobber_${CONFIG}.yaml" \
         --extra-meta flow_run_id="${flow_run_id:-}" remote_url="${remote_url:-}" sha="${sha:-}"

--- a/.scripts/run_osx_build.sh
+++ b/.scripts/run_osx_build.sh
@@ -26,9 +26,9 @@ export CONDA_SOLVER="libmamba"
 export CONDA_LIBMAMBA_SOLVER_NO_CHANNELS_FROM_INSTALLED=1
 
 mamba install --update-specs --quiet --yes --channel conda-forge --strict-channel-priority \
-    pip mamba conda-build conda-forge-ci-setup=4
+    pip mamba conda-build boa conda-forge-ci-setup=4
 mamba update --update-specs --yes --quiet --channel conda-forge --strict-channel-priority \
-    pip mamba conda-build conda-forge-ci-setup=4
+    pip mamba conda-build boa conda-forge-ci-setup=4
 
 
 
@@ -81,7 +81,7 @@ else
         EXTRA_CB_OPTIONS="${EXTRA_CB_OPTIONS:-} --no-test"
     fi
 
-    conda build ./recipe -m ./.ci_support/${CONFIG}.yaml \
+    conda mambabuild ./recipe -m ./.ci_support/${CONFIG}.yaml \
         --suppress-variables ${EXTRA_CB_OPTIONS:-} \
         --clobber-file ./.ci_support/clobber_${CONFIG}.yaml \
         --extra-meta flow_run_id="$flow_run_id" remote_url="$remote_url" sha="$sha"

--- a/.scripts/run_win_build.bat
+++ b/.scripts/run_win_build.bat
@@ -24,7 +24,7 @@ set "CONDA_LIBMAMBA_SOLVER_NO_CHANNELS_FROM_INSTALLED=1"
 
 :: Provision the necessary dependencies to build the recipe later
 echo Installing dependencies
-mamba.exe install "python=3.10" pip mamba conda-build conda-forge-ci-setup=4 -c conda-forge --strict-channel-priority --yes
+mamba.exe install "python=3.10" pip mamba conda-build boa conda-forge-ci-setup=4 -c conda-forge --strict-channel-priority --yes
 if !errorlevel! neq 0 exit /b !errorlevel!
 
 :: Set basic configuration
@@ -42,7 +42,9 @@ if EXIST LICENSE.txt (
     copy LICENSE.txt "recipe\\recipe-scripts-license.txt"
 )
 if NOT [%HOST_PLATFORM%] == [%BUILD_PLATFORM%] (
-    set "EXTRA_CB_OPTIONS=%EXTRA_CB_OPTIONS% --no-test"
+    if [%CROSSCOMPILING_EMULATOR%] == [] (
+        set "EXTRA_CB_OPTIONS=%EXTRA_CB_OPTIONS% --no-test"
+    )
 )
 
 if NOT [%flow_run_id%] == [] (
@@ -53,7 +55,7 @@ call :end_group
 
 :: Build the recipe
 echo Building recipe
-conda.exe build "recipe" -m .ci_support\%CONFIG%.yaml --suppress-variables %EXTRA_CB_OPTIONS%
+conda.exe mambabuild "recipe" -m .ci_support\%CONFIG%.yaml --suppress-variables %EXTRA_CB_OPTIONS%
 if !errorlevel! neq 0 exit /b !errorlevel!
 
 :: Prepare some environment variables for the upload step

--- a/.scripts/run_win_build.bat
+++ b/.scripts/run_win_build.bat
@@ -24,7 +24,7 @@ set "CONDA_LIBMAMBA_SOLVER_NO_CHANNELS_FROM_INSTALLED=1"
 
 :: Provision the necessary dependencies to build the recipe later
 echo Installing dependencies
-mamba.exe install "python=3.10" pip mamba conda-build boa conda-forge-ci-setup=4 -c conda-forge --strict-channel-priority --yes
+mamba.exe install "python=3.10" pip mamba "conda-build<3.28" boa conda-forge-ci-setup=4 -c conda-forge --strict-channel-priority --yes
 if !errorlevel! neq 0 exit /b !errorlevel!
 
 :: Set basic configuration


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
Once this passes, it will be pushed to a different branch to produce the artifacts but not revert the fmt10 migration on the main branch.